### PR TITLE
[squid:S2864] "entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/davinci/src/main/java/cn/hadcn/davinci/http/impl/HttpRequest.java
+++ b/davinci/src/main/java/cn/hadcn/davinci/http/impl/HttpRequest.java
@@ -148,8 +148,8 @@ public class HttpRequest {
         //construct url
         if ( null != urlMap ){
             requestUrl += "?";
-            for ( String key : urlMap.keySet() ) {
-                requestUrl = requestUrl + key + "=" + urlMap.get(key) + "&";
+            for (Map.Entry<String, Object> entry : urlMap.entrySet()) {
+                requestUrl = requestUrl + entry.getKey() + "=" + entry.getValue() + "&";
             }
         }
 

--- a/davinci/src/main/java/cn/hadcn/davinci/http/impl/PersistentCookieStore.java
+++ b/davinci/src/main/java/cn/hadcn/davinci/http/impl/PersistentCookieStore.java
@@ -148,12 +148,12 @@ public class PersistentCookieStore implements CookieStore {
         List<HttpCookie> targetCookies = new ArrayList<HttpCookie>();
         // If the stored URI does not have a path then it must match any URI in
         // the same domain
-        for (URI storedUri : allCookies.keySet()) {
+        for (Map.Entry<URI, Set<HttpCookie>> entry : allCookies.entrySet()) {
             // Check ith the domains match according to RFC 6265
-            if (checkDomainsMatch(storedUri.getHost(), uri.getHost())) {
+            if (checkDomainsMatch(entry.getKey().getHost(), uri.getHost())) {
                 // Check if the paths match according to RFC 6265
-                if (checkPathsMatch(storedUri.getPath(), uri.getPath())) {
-                    targetCookies.addAll(allCookies.get(storedUri));
+                if (checkPathsMatch(entry.getKey().getPath(), uri.getPath())) {
+                    targetCookies.addAll(entry.getValue());
                 }
             }
         }

--- a/davinci/src/main/java/cn/hadcn/davinci/volley/toolbox/HttpClientStack.java
+++ b/davinci/src/main/java/cn/hadcn/davinci/volley/toolbox/HttpClientStack.java
@@ -58,16 +58,16 @@ public class HttpClientStack implements HttpStack {
     }
 
     private static void addHeaders(HttpUriRequest httpRequest, Map<String, String> headers) {
-        for (String key : headers.keySet()) {
-            httpRequest.setHeader(key, headers.get(key));
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            httpRequest.setHeader(entry.getKey(), entry.getValue());
         }
     }
 
     @SuppressWarnings("unused")
     private static List<NameValuePair> getPostParameterPairs(Map<String, String> postParams) {
         List<NameValuePair> result = new ArrayList<NameValuePair>(postParams.size());
-        for (String key : postParams.keySet()) {
-            result.add(new BasicNameValuePair(key, postParams.get(key)));
+        for (Map.Entry<String, String> entry : postParams.entrySet()) {
+            result.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
         }
         return result;
     }

--- a/davinci/src/main/java/cn/hadcn/davinci/volley/toolbox/HurlStack.java
+++ b/davinci/src/main/java/cn/hadcn/davinci/volley/toolbox/HurlStack.java
@@ -102,8 +102,8 @@ public class HurlStack implements HttpStack {
         }
         URL parsedUrl = new URL(url);
         HttpURLConnection connection = openConnection(parsedUrl, request);
-        for (String headerName : map.keySet()) {
-            connection.addRequestProperty(headerName, map.get(headerName));
+        for (Entry<String, String> entry : map.entrySet()) {
+            connection.addRequestProperty(entry.getKey(), entry.getValue());
         }
         setConnectionParametersForRequest(connection, request);
         // Initialize HttpResponse with data from the HttpURLConnection.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864

Please let me know if you have any questions.
Ayman Abdelghany.
