### PR TITLE
[squid:S1143] "return" statements should not occur in "finally" blocks

### DIFF
--- a/davinci/src/main/java/cn/hadcn/davinci/volley/toolbox/DiskBasedCache.java
+++ b/davinci/src/main/java/cn/hadcn/davinci/volley/toolbox/DiskBasedCache.java
@@ -110,27 +110,28 @@ public class DiskBasedCache implements Cache {
         if (entry == null) {
             return null;
         }
-
+        Entry resultEntry = null;
         File file = getFileForKey(key);
         CountingInputStream cis = null;
         try {
             cis = new CountingInputStream(new BufferedInputStream(new FileInputStream(file)));
             CacheHeader.readHeader(cis); // eat header
             byte[] data = streamToBytes(cis, (int) (file.length() - cis.bytesRead));
-            return entry.toCacheEntry(data);
+            resultEntry = entry.toCacheEntry(data);
         } catch (IOException e) {
             VolleyLog.d("%s: %s", file.getAbsolutePath(), e.toString());
             remove(key);
-            return null;
+            resultEntry = null;
         } finally {
             if (cis != null) {
                 try {
                     cis.close();
                 } catch (IOException ioe) {
-                    return null;
+                    resultEntry = null;
                 }
             }
         }
+        return resultEntry;
     }
 
     /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1143 - “"return" statements should not occur in "finally" blocks”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1143

Please let me know if you have any questions.
Ayman Abdelghany.
